### PR TITLE
Add command line support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ npm install --save md5-file
 
 ## Usage
 
+### As a module
 ```js
 const md5File = require('md5-file')
 
@@ -23,6 +24,11 @@ md5File('LICENSE.md', (err, hash) => {
 /* Sync usage */
 const hash = md5File.sync('LICENSE.md')
 console.log(`The MD5 sum of LICENSE.md is: ${hash}`)
+```
+
+### As a command line tool
+```
+$ md5-file LICENSE.md
 ```
 
 ## Promise support

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function md5File (filename, cb) {
 }
 
 if (require.main === module) {
-  console.log(md5FileSync(process.argv[2]));
+  console.log(md5FileSync(process.argv[2]))
 }
 
 module.exports = md5File

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict'
 
 var crypto = require('crypto')
@@ -39,6 +40,10 @@ function md5File (filename, cb) {
   })
 
   input.pipe(output)
+}
+
+if (require.main === module) {
+  console.log(md5FileSync(process.argv[2]));
 }
 
 module.exports = md5File

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "test": "standard && mocha"
   },
+  "bin": "index.js",
   "devDependencies": {
     "mocha": "^2.4.5",
     "standard": "^7.1.0"


### PR DESCRIPTION
With this PR, it is possible to install the module globally and use it via the command line:

```
$ npm install -g md5-file
$ md5-file LICENSE.md
> 687d0001c49a6315989af72c0325dff3
```