### PR TITLE
Restore compatibility with Node.js 0.10 and up

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,14 @@
 
 var crypto = require('crypto')
 var fs = require('fs')
+var alloc = require('buffer-alloc')
 
 var BUFFER_SIZE = 8192
 
 function md5FileSync (filename) {
   var fd = fs.openSync(filename, 'r')
   var hash = crypto.createHash('md5')
-  var buffer = Buffer.alloc(BUFFER_SIZE)
+  var buffer = alloc(BUFFER_SIZE)
 
   try {
     var bytesRead

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "standard": "^7.1.0"
   },
   "engines": {
-    "node": ">=4.5.0"
+    "node": ">=0.10"
+  },
+  "dependencies": {
+    "buffer-alloc": "^1.1.0"
   }
 }


### PR DESCRIPTION
I think that if we are going to drop older versions of Node.js, it should be in a breaking change. As it is now we could potentially have broken some packages using the `~` or `^` specifier in their dependencies.

(I would be happy to make a 2.x release with dropped support btw; although I'm not sure if it's wise to drop any 4.x releases until April 2018 [ref](https://github.com/nodejs/LTS#lts-schedule1))

Cheers 👋 