### PR TITLE
Require Node.js >= 6.0 to drop the dependency on buffer-alloc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 'use strict'
 
-var crypto = require('crypto')
-var fs = require('fs')
+const crypto = require('crypto')
+const fs = require('fs')
 
-var BUFFER_SIZE = 8192
+const BUFFER_SIZE = 8192
 
 function md5FileSync (filename) {
-  var fd = fs.openSync(filename, 'r')
-  var hash = crypto.createHash('md5')
-  var buffer = Buffer.alloc(BUFFER_SIZE)
+  const fd = fs.openSync(filename, 'r')
+  const hash = crypto.createHash('md5')
+  const buffer = Buffer.alloc(BUFFER_SIZE)
 
   try {
-    var bytesRead
+    let bytesRead
 
     do {
       bytesRead = fs.readSync(fd, buffer, 0, BUFFER_SIZE)
@@ -27,8 +27,8 @@ function md5FileSync (filename) {
 function md5File (filename, cb) {
   if (typeof cb !== 'function') throw new TypeError('Argument cb must be a function')
 
-  var output = crypto.createHash('md5')
-  var input = fs.createReadStream(filename)
+  const output = crypto.createHash('md5')
+  const input = fs.createReadStream(filename)
 
   input.on('error', function (err) {
     cb(err)

--- a/index.js
+++ b/index.js
@@ -2,14 +2,13 @@
 
 var crypto = require('crypto')
 var fs = require('fs')
-var alloc = require('buffer-alloc')
 
 var BUFFER_SIZE = 8192
 
 function md5FileSync (filename) {
   var fd = fs.openSync(filename, 'r')
   var hash = crypto.createHash('md5')
-  var buffer = alloc(BUFFER_SIZE)
+  var buffer = Buffer.alloc(BUFFER_SIZE)
 
   try {
     var bytesRead

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "standard": "^11.0.1"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=6.0"
   },
   "dependencies": {
     "buffer-alloc": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
   },
   "engines": {
     "node": ">=6.0"
-  },
-  "dependencies": {
-    "buffer-alloc": "^1.1.0"
   }
 }

--- a/promise.js
+++ b/promise.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var md5File = require('./')
+const md5File = require('./')
 
 function md5FileAsPromised (filename) {
   return new Promise(function (resolve, reject) {

--- a/test.js
+++ b/test.js
@@ -44,12 +44,9 @@ describe('md5File', function () {
       {},
       123,
       null,
-      undefined
+      undefined,
+      Symbol('test')
     ]
-
-    if (typeof Symbol !== 'undefined') {
-      invalidValues.push(Symbol('test'))
-    }
 
     invalidValues.forEach(function (value) {
       assert.throws(function () { md5File.sync(value) }, TypeError)

--- a/test.js
+++ b/test.js
@@ -2,12 +2,12 @@
 
 'use strict'
 
-var md5File = require('./')
-var md5FileAsPromised = require('./promise')
-var assert = require('assert')
+const md5File = require('./')
+const md5FileAsPromised = require('./promise')
+const assert = require('assert')
 
-var filename = 'LICENSE.md'
-var preCheckedSum = 'ad1faf9381e43c471dc381c17a4ee4b6'
+const filename = 'LICENSE.md'
+const preCheckedSum = 'ad1faf9381e43c471dc381c17a4ee4b6'
 
 function noop () {}
 


### PR DESCRIPTION
Would make this package completely dependency free 🎉 

Maintenance for Node.js 4 will end April 30th.

Also did some other refectorings/cleanups made possible by dropping Node 0.10/0.12. Let me know if any of them are undesirable to you and I'll back them out.